### PR TITLE
fix: ignore stale checks from closed PRs

### DIFF
--- a/src/poll.ts
+++ b/src/poll.ts
@@ -84,6 +84,10 @@ export async function poll(config: Config): Promise<void> {
         run => !ignoreChecks.includes(run.name)
       )
 
+      // ignore checks that don't match an open PR
+      // this ensures that stale checks (e.g., from closed PRs) are ignored
+      check_runs = check_runs.filter(run => run.pull_requests.length > 0)
+
       // filter by match pattern
       if (matchPattern) {
         core.debug(`Filtering check runs by match pattern: ${matchPattern}`)


### PR DESCRIPTION
This ensures that checks are only considered if they match an open PR. This is useful for scenarios when a branch name changes but the commit SHA stays the same.

<img width="913" alt="Screenshot 2024-09-20 at 2 00 47 PM" src="https://github.com/user-attachments/assets/afb9672a-38db-440b-bfe2-463e9f9ef2b9">