### PR TITLE
Upgrade GitHub Action runtime to Node 24

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v7.0.0
         with:
           node-version: 24.x

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
   ignore:
     description: 'GitHub checks that should be ignored (default ignores the current job)'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
* Replace deprecated Node 20 runtime with Node 24 before the next release
* Align the distribution workflow label with its existing Node 24 configuration
* Validate YAML syntax and bundled action parsing with Node 24